### PR TITLE
Fixing deprecated ESLint rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,7 +16,7 @@
     "eol-last": 0,
     "quotes": [2, "single"],
     "react/jsx-boolean-value": 1,
-    "react/jsx-quotes": 1,
+    "jsx-quotes": 1,
     "react/jsx-no-undef": 1,
     "react/jsx-uses-react": 1,
     "react/jsx-uses-vars": 1


### PR DESCRIPTION
Per here: https://github.com/airbnb/javascript/issues/513
